### PR TITLE
Insert Google Plus button div into Custom Element, instead of `document.body`

### DIFF
--- a/dist/gplus-button.html
+++ b/dist/gplus-button.html
@@ -17,7 +17,7 @@
             height      : 20,
             type        : "g-plusone",
 
-            created: function () {
+            ready: function () {
                 var script = document.createElement("script"),
                     div = document.createElement("div"),
                     body = document.body;
@@ -42,7 +42,7 @@
                     div.setAttribute("annotation", this.annotation);
                 }
 
-                body.appendChild(div);
+                this.appendChild(div);
                 body.appendChild(script);
             }
         });

--- a/src/gplus-button.html
+++ b/src/gplus-button.html
@@ -42,7 +42,7 @@
                     div.setAttribute("annotation", this.annotation);
                 }
 
-                body.appendChild(div);
+                this.appendChild(div);
                 body.appendChild(script);
             }
         });


### PR DESCRIPTION
(fix for webcomponents/customelements.io#4)
